### PR TITLE
Fix/suggestions show

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pg', '~> 0.21'
 gem 'puma'
 gem 'rails', '6.0.2.2'
 gem 'redis'
+gem 'bootstrap', '~> 4.4.1'
 
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 5.12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,12 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
+    bootstrap (4.4.1)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 1.14.3, < 2)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
-    byebug (11.1.2)
+    byebug (11.1.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
@@ -110,6 +114,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     pg (0.21.0)
+    popper_js (1.16.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -205,7 +210,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webpacker (5.1.0)
+    webpacker (5.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -221,6 +226,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   bootsnap
+  bootstrap (~> 4.4.1)
   devise
   dotenv-rails
   font-awesome-sass (~> 5.12.0)

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -1,5 +1,7 @@
 class SuggestionsController < ApplicationController
 
+  before_action :set_suggestion_skip, only: [ :pass_suggestion, :move_to_later, :already_seen ]
+
   def index
     @suggestion = Suggestion.all
   end
@@ -17,6 +19,7 @@ class SuggestionsController < ApplicationController
   def show
     # the show accepts a parameter from the filters page
     # the @tmdb_suggestion declaration is temporary, until we successfully receive sample tmdb_suggestions
+
     @current_suggestion = []
     @tmdb_suggestion = TmdbSuggestion.first.suggestions
 
@@ -41,11 +44,11 @@ class SuggestionsController < ApplicationController
     redirect_to pages_suggestions_path
   end
 
-  def set_true
-    @suggestion = Suggestion.find(params[:suggestion_id])
-    @suggestion.update(skip: true)
-    redirect_to results_path
-  end
+  def pass_suggestion; end
+
+  def move_to_later; end
+
+  def already_seen; end
 
   # def destroy
   #   @suggestion = Suggestion.find(params[:id])
@@ -57,6 +60,12 @@ class SuggestionsController < ApplicationController
 
   def suggestion_params
     params.require(:suggestion).permit( :tmdb_suggestion_id, :movie_id, :skip)
+  end
+
+  def set_suggestion_skip
+    @suggestion = Suggestion.find(params[:suggestion_id])
+    @suggestion.update(skip: true)
+    redirect_to results_path
   end
 
 end

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -15,21 +15,35 @@ class SuggestionsController < ApplicationController
   end
 
   def show
-    @suggestion = Suggestion.find(params[:id])
-    @movies = Movie.all
-    @tmdb_suggestions = TmdbSuggestion.all
+    # the show accepts a parameter from the filters page
+    # the @tmdb_suggestion declaration is temporary, until we successfully receive sample tmdb_suggestions
+    @current_suggestion = []
+    @tmdb_suggestion = TmdbSuggestion.first.suggestions
+
+    @tmdb_suggestion.each do |suggestion|
+      if suggestion.skip == false
+        @current_suggestion << suggestion
+        break
+      end
+    end
+
   end
 
   def edit
-    @suggestion = Suggestion.find(params[:id])
-    @suggestion.update(skip: true)
-    redirect_to_pages_suggestions_path
+    # @suggestion = Suggestion.find(params[:id])
+    # @suggestion.update(skip: true)
+    # redirect_to pages_suggestions_path
   end
 
   def update
-    @suggestion = suggestion.find(params[:id])
+    @suggestion = Suggestion.find(params[:id])
     @suggestion.update(suggestion_params)
-    redirect_to_pages_suggestions_path
+    redirect_to pages_suggestions_path
+  end
+
+  def set_true
+    @suggestion = params[:id]
+    @suggestion.update(skip: true)
   end
 
   # def destroy

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -1,5 +1,6 @@
 class SuggestionsController < ApplicationController
 
+  # calls method to set suggestion.skip to true, if user clicks on the pass, later, or seen button in show
   before_action :set_suggestion_skip, only: [ :pass_suggestion, :move_to_later, :already_seen ]
 
   def index
@@ -44,10 +45,11 @@ class SuggestionsController < ApplicationController
     redirect_to pages_suggestions_path
   end
 
+
+  # controller methods for pass, later, seen buttons in show
+  # TODO: each method must be updated with the necessary function(s) for each button action
   def pass_suggestion; end
-
   def move_to_later; end
-
   def already_seen; end
 
   # def destroy
@@ -62,6 +64,8 @@ class SuggestionsController < ApplicationController
     params.require(:suggestion).permit( :tmdb_suggestion_id, :movie_id, :skip)
   end
 
+
+  # method to set current suggestion.skip displayed in show to true, then present next suggestion to show
   def set_suggestion_skip
     @suggestion = Suggestion.find(params[:suggestion_id])
     @suggestion.update(skip: true)

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -42,8 +42,9 @@ class SuggestionsController < ApplicationController
   end
 
   def set_true
-    @suggestion = params[:id]
+    @suggestion = Suggestion.find(params[:suggestion_id])
     @suggestion.update(skip: true)
+    redirect_to results_path
   end
 
   # def destroy

--- a/app/views/suggestions/show.html.erb
+++ b/app/views/suggestions/show.html.erb
@@ -19,7 +19,7 @@
 <% available_services.each do |service| %>
   <p><%= Service.find(service.service_id).company %></p>
 <% end %>
-<%= link_to 'Pass', set_true_path(@current_suggestion), remote: true %>
+<%= link_to 'Pass', set_true_path(suggestion_id: @current_suggestion.first.id), method: :patch %>
 <%= link_to 'Later' %>
 <%= link_to 'Seen' %>
 <%= link_to 'Watch' %>

--- a/app/views/suggestions/show.html.erb
+++ b/app/views/suggestions/show.html.erb
@@ -19,7 +19,7 @@
 <% available_services.each do |service| %>
   <p><%= Service.find(service.service_id).company %></p>
 <% end %>
-<%= link_to 'Pass', set_true_path(suggestion_id: @current_suggestion.first.id), method: :patch %>
-<%= link_to 'Later' %>
-<%= link_to 'Seen' %>
+<%= link_to 'Pass', pass_suggestion_path(suggestion_id: @current_suggestion.first.id), method: :patch %>
+<%= link_to 'Later', move_to_later_path(suggestion_id: @current_suggestion.first.id), method: :patch %>
+<%= link_to 'Seen', already_seen_path(suggestion_id: @current_suggestion.first.id), method: :patch %>
 <%= link_to 'Watch' %>

--- a/app/views/suggestions/show.html.erb
+++ b/app/views/suggestions/show.html.erb
@@ -1,26 +1,25 @@
-<% User.first.tmdb_suggestions.first.suggestions.each do |suggestion| %>
-  <% if suggestion.skip == false %>
-    <% suggested_movie = suggestion.movie %>
-    <% movie_director = suggested_movie.director %>
-    <% starring_actors = suggested_movie.starring_actors %>
-    <% available_services = suggested_movie.available_services %>
-    <h2><%= suggested_movie.title %></h3>
-    <p><%= suggested_movie.release_date %></p>
-    <p><%= suggested_movie.runtime %> minutes</p>
-    <p><%= suggested_movie.overview %></p>
-    <h3>Starring Actors:</h3>
-    <% starring_actors.each do |actor| %>
-      <p><%= Actor.find(actor.actor_id).name %></p>
-    <% end %>
-    <h3>Director: </h3>
-    <p><%= movie_director.name %></p>
-    <h3>Available on: </h3>
-    <% available_services.each do |service| %>
-      <p><%= Service.find(service.service_id).company %></p>
-    <% end %>
-  <% end %>
-  <%= link_to 'Pass', suggestion_path, method: :show, 'btn btn-primary' %>
-    <%= link_to 'Later', show_suggestion_path, 'btn btn-primary' %>
-    <%= link_to 'Seen', show_suggestion_path, 'btn btn-primary' %>
-    <%= link_to 'Watch', show_suggestion_path, 'btn btn-primary' %>
+
+<!-- should be current_user -->
+<% movie_director = @current_suggestion.first.movie.director %>
+<% starring_actors = @current_suggestion.first.movie.starring_actors %>
+<% available_services = @current_suggestion.first.movie.available_services %>
+<%= image_tag "https://image.tmdb.org/t/p/w300/#{@current_suggestion.first.movie.photo_url}" %>
+<h2><%= @current_suggestion.first.movie.title %></h3>
+<p><%= @current_suggestion.first.movie.release_date %></p>
+<p><%= @current_suggestion.first.movie.runtime %> minutes</p>
+<p><%= @current_suggestion.first.movie.overview %></p>
+<h3>Starring Actors:</h3>
+<!-- Line below should only display the first 7 actors (quantity to be confirmed with group) -->
+<% starring_actors.take(7).each do |actor| %>
+  <p><%= Actor.find(actor.actor_id).name %></p>
 <% end %>
+<h3>Director: </h3>
+<p><%= movie_director.name %></p>
+<h3>Available on: </h3>
+<% available_services.each do |service| %>
+  <p><%= Service.find(service.service_id).company %></p>
+<% end %>
+<%= link_to 'Pass', set_true_path(@current_suggestion), remote: true %>
+<%= link_to 'Later' %>
+<%= link_to 'Seen' %>
+<%= link_to 'Watch' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,10 @@ Rails.application.routes.draw do
 
   # routes related to 'Watch now' button in navbar
   get '/search', to: 'suggestions#home'
-  get '/suggestion/:id', to: 'suggestions#show'
-  patch '/suggestion/:id', to: 'suggestions#set_true', as: 'set_true'
+
+  # [KK - 23 Apr] removed the /:id from URI - will not be needed for our logic
+  get '/results', to: 'suggestions#show'
+  patch '/results', to: 'suggestions#set_true', as: 'set_true'
   # pass, later and seen buttons won't trigger a new route, they will trigger only different methods that will
   # be activated based on the JS button listener. These methods will be created in the suggestions controller
   get '/suggestion/:id/confirmation', to: 'suggestions#confirmation', as: 'confirmation'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,8 @@ Rails.application.routes.draw do
   # routes related to 'Watch now' button in navbar
   get '/search', to: 'suggestions#home'
   get '/suggestion/:id', to: 'suggestions#show'
+  patch '/suggestion/:id', to: 'suggestions#set_true', as: 'set_true'
   # pass, later and seen buttons won't trigger a new route, they will trigger only different methods that will
   # be activated based on the JS button listener. These methods will be created in the suggestions controller
-  get '/suggestion/:id/confirmation', to: 'suggestions#confirmation'
+  get '/suggestion/:id/confirmation', to: 'suggestions#confirmation', as: 'confirmation'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,9 @@ Rails.application.routes.draw do
 
   # [KK - 23 Apr] removed the /:id from URI - will not be needed for our logic
   get '/results', to: 'suggestions#show'
-  patch '/results', to: 'suggestions#set_true', as: 'set_true'
+  patch '/results', to: 'suggestions#pass_suggestion', as: 'pass_suggestion'
+  patch '/results', to: 'suggestions#move_to_later', as: 'move_to_later'
+  patch '/results', to: 'suggestions#already_seen', as: 'already_seen'
   # pass, later and seen buttons won't trigger a new route, they will trigger only different methods that will
   # be activated based on the JS button listener. These methods will be created in the suggestions controller
   get '/suggestion/:id/confirmation', to: 'suggestions#confirmation', as: 'confirmation'


### PR DESCRIPTION
created new logic around the suggestions show page:

1. suggestions show no longer iterates over every suggestion; instead, the suggestions controller has a 'show' method that presents a single suggestion

2. controller has a unique method for the pass, later, and seen buttons in the suggestion show; clicking on any of these three buttons should now refresh the page and display the next suggestion to the user